### PR TITLE
use our own getOrDefault(), which has backwards compat

### DIFF
--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/Session.java
@@ -445,15 +445,9 @@ public class Session implements ISession, ITransportHandler {
                         msg.registration));
             }
 
-            long callerSessionID = msg.details != null 
-                    ? (long) msg.details.getOrDefault("caller", -1L) 
-                    : -1L; 
-            String callerAuthID = msg.details != null
-            		? (String) msg.details.getOrDefault("caller_authid", null) 
-            		: null;
-            String callerAuthRole = msg.details != null
-            		? (String) msg.details.getOrDefault("caller_authrole", null) 
-            		: null;
+            long callerSessionID = getOrDefault(msg.details, "caller", -1L);
+            String callerAuthID = getOrDefault(msg.details, "caller_authid", null);
+            String callerAuthRole = getOrDefault(msg.details, "caller_authrole", null);
             
             InvocationDetails details = new InvocationDetails(
                     registration, registration.procedure, callerSessionID, callerAuthID, callerAuthRole, this);

--- a/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Invocation.java
+++ b/autobahn/src/main/java/io/crossbar/autobahn/wamp/messages/Invocation.java
@@ -40,7 +40,7 @@ public class Invocation implements IMessage {
     }
 
     public static Invocation parse(List<Object> wmsg) {
-        MessageUtil.validateMessage(wmsg, MESSAGE_TYPE, "INNVOCATION", 3, 6);
+        MessageUtil.validateMessage(wmsg, MESSAGE_TYPE, "INVOCATION", 4, 6);
 
         long request = MessageUtil.parseLong(wmsg.get(1));
         long registration = MessageUtil.parseLong(wmsg.get(2));


### PR DESCRIPTION
Also the wamp spec expects `details` property to be "empty" and not null, so we don't need to check if its null ;-) https://wamp-proto.org/_static/gen/wamp_latest_ietf.html#invocation-1